### PR TITLE
Turns a binary private key into a Wallet Import Format

### DIFF
--- a/lib/ex_wallet/wif.ex
+++ b/lib/ex_wallet/wif.ex
@@ -1,0 +1,23 @@
+defmodule ExWallet.Wif do
+  alias ExWallet.Base58
+  alias ExWallet.Extended.Private
+
+  @prefixes %{
+    main: <<0x80>>,
+    test: <<0xef>>
+  }
+
+  def priv_to_wif(key, network \\ :main)
+  def priv_to_wif(%Private{key: key}, network), do: priv_to_wif(key, network)
+  def priv_to_wif(key, network) when is_binary(key) do
+    key
+    |> prepend_symbol(network)
+    |> Base58.check_encode()
+  end
+
+  defp prepend_symbol(key, network) do
+    @prefixes
+    |> Map.get(network)
+    |> Kernel.<>(key)
+  end
+end

--- a/test/ex_wallet/wif_test.exs
+++ b/test/ex_wallet/wif_test.exs
@@ -1,0 +1,27 @@
+defmodule ExWallet.WifTest do
+  use ExUnit.Case, async: true
+
+  alias ExWallet.Wif
+
+  # source of tests: https://en.bitcoin.it/wiki/Wallet_import_format
+  setup do
+    # Here we convert the hex representation of the private key, into a binary <<12, ...>>
+    hex_priv = "0C28FCA386C7A227600B2FE50B7CAE11EC86D3BF1FBE471BE89827E19D72AA1D"
+
+    priv =
+      for <<x::binary-2 <- hex_priv>> do
+        x
+      end
+      |> Enum.map(&String.to_integer(&1, 16))
+      |> Enum.reverse
+      |> Enum.reduce(<<>>, fn x, acc -> <<x>> <> acc end)
+
+    [priv: priv]
+  end
+
+  test "Converts private key into wallet import format", %{priv: priv} do
+    result = Wif.priv_to_wif(priv)
+
+    assert result == "5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ"
+  end
+end


### PR DESCRIPTION
We have a key in binary format `<<12, 195, ...>>`, but to use the private key into the node we need to pass it as a "Wallet Import Format".

An example of this would be to use `signrawtransaction` from Bitcoin Core, passing the private keys explicitly.

You can read more about it here: https://en.bitcoin.it/wiki/Wallet_import_format