### PR TITLE
Fix children private key generation

### DIFF
--- a/lib/ex_wallet/extended/children.ex
+++ b/lib/ex_wallet/extended/children.ex
@@ -68,7 +68,13 @@ defmodule ExWallet.Extended.Children do
     |> Kernel.+(key)
     |> rem(@curve_order)
     |> :binary.encode_unsigned()
+    |> set_32_bytesize()
   end
+
+  defp set_32_bytesize(priv_key) when byte_size(priv_key) < 32,
+    do: set_32_bytesize(<<0>> <> priv_key)
+
+  defp set_32_bytesize(priv_key), do: priv_key
 
   defp elliptic_curve_point_addition(
          <<derived_key::binary-32, child_chain::binary>>,

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,8 @@ defmodule ExWallet.MixProject do
     [
       {:poison, "~> 3.1"},
       {:libsecp256k1, "~> 0.1.10"},
-      {:silicon, "~> 0.1.0"}
+      {:silicon, "~> 0.1.0"},
+      {:stream_data, "~> 0.4"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -7,4 +7,5 @@
   "mix_erlang_tasks": {:hex, :mix_erlang_tasks, "0.1.0", "36819fec60b80689eb1380938675af215565a89320a9e29c72c70d97512e4649", [:mix], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "silicon": {:hex, :silicon, "0.1.0", "05653c16143257f7d244e74e3086a30cb9d82b29182a31b2f10a186565fb809f", [:mix], [{:blake2_elixir, "~> 0.8", [hex: :blake2_elixir, repo: "hexpm", optional: false]}, {:keccakf1600, "~> 2.0", [hex: :keccakf1600_orig, repo: "hexpm", optional: false]}, {:libdecaf, "~> 1.0", [hex: :libdecaf, repo: "hexpm", optional: false]}, {:libsecp256k1, "~> 0.1.10", [hex: :libsecp256k1, repo: "hexpm", optional: false]}], "hexpm"},
+  "stream_data": {:hex, :stream_data, "0.4.3", "62aafd870caff0849a5057a7ec270fad0eb86889f4d433b937d996de99e3db25", [:mix], [], "hexpm"},
 }

--- a/test/ex_wallet/extended/children_test.exs
+++ b/test/ex_wallet/extended/children_test.exs
@@ -150,6 +150,28 @@ defmodule ExWallet.Extended.ChildrenTest do
     end
   end
 
+  describe "children private key generator" do
+    use ExUnitProperties
+
+    require Integer
+
+    property "generates private keys with 32 bytes" do
+      check all seed <- positive_integer(),
+                child <- positive_integer(),
+                max_runs: 400 do
+        private_key =
+          seed
+          |> Integer.to_string()
+          |> Base.encode16()
+          |> Extended.master()
+          |> Children.derive("m/0'/1/2'/2/#{child}")
+          |> Map.get(:key)
+
+        assert byte_size(private_key) == 32
+      end
+    end
+  end
+
   defp derive(master_key, chain) do
     master_key
     |> Children.derive(chain)


### PR DESCRIPTION
A propery private should have 32 bytes to sign
transaction contracts.